### PR TITLE
tss: Reset size/count fields on unmarshaling failures to prevent reus…

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: output
 
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: output
 
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,19 +16,19 @@ jobs:
         run: |
           brew install create-dmg
 
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: output
 
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: qemu_macos
 
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,19 +16,19 @@ jobs:
         run: |
           brew install create-dmg
 
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: output
 
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: qemu_macos
 
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,19 +12,19 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: output
 
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: qemu_w64
 
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,19 +12,19 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: output
 
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: qemu_w64
 
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success

--- a/qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/Commands12.c
+++ b/qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/Commands12.c
@@ -68,6 +68,7 @@ ActivateIdentity_In_Unmarshal(ActivateIdentity_In *target, BYTE **buffer, uint32
     if (rc == 0) {
 	if (target->blobSize > sizeof(target->blob)) {
 	    rc = TPM_RC_SIZE;
+	    target->blobSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -181,6 +182,7 @@ GetCapability12_In_Unmarshal(GetCapability12_In *target, BYTE **buffer, uint32_t
     if (rc == 0) {
 	if (target->subCapSize > sizeof(target->subCap)) {
 	    rc = TPM_RC_SIZE;
+	    target->subCapSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -326,6 +328,7 @@ NV_WriteValue_In_Unmarshal(NV_WriteValue_In *target, BYTE **buffer, uint32_t *si
     if (rc == 0) {
 	if (target->dataSize > sizeof(target->data)) {
 	    rc = TPM_RC_SIZE;
+		target->dataSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -360,6 +363,7 @@ NV_WriteValueAuth_In_Unmarshal(NV_WriteValueAuth_In *target, BYTE **buffer, uint
     if (rc == 0) {
 	if (target->dataSize > sizeof(target->data)) {
 	    rc = TPM_RC_SIZE;
+		target->dataSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -516,6 +520,7 @@ Sign12_In_Unmarshal(Sign12_In *target, BYTE **buffer, uint32_t *size, TPM_HANDLE
     if (rc == 0) {
 	if (target->areaToSignSize > sizeof(target->areaToSign)) {
 	    rc = TPM_RC_SIZE;
+	    target->areaToSignSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -563,6 +568,7 @@ TakeOwnership_In_Unmarshal(TakeOwnership_In *target, BYTE **buffer, uint32_t *si
      if (rc == 0) {
 	 if (target->encOwnerAuthSize > sizeof(target->encOwnerAuth)) {
 	    rc = TPM_RC_SIZE;
+	    target->encOwnerAuthSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -580,6 +586,7 @@ TakeOwnership_In_Unmarshal(TakeOwnership_In *target, BYTE **buffer, uint32_t *si
     if (rc == 0) {
 	if (target->encSrkAuthSize > sizeof(target->encSrkAuth)) {
 	    rc = TPM_RC_SIZE;
+	    target->encSrkAuthSize = 0;
 	}
     }    
     if (rc == 0) {

--- a/qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/Unmarshal.c
+++ b/qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/Unmarshal.c
@@ -192,6 +192,7 @@ TSS_TPM2B_Unmarshalu(TPM2B *target, uint16_t targetSize, BYTE **buffer, uint32_t
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size > targetSize) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0;
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -1601,6 +1602,7 @@ TSS_TPML_CC_Unmarshalu(TPML_CC *target, BYTE **buffer, uint32_t *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_CC) {
 	    rc = TPM_RC_SIZE;
+        target->count = 0;
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1623,6 +1625,7 @@ TSS_TPML_CCA_Unmarshalu(TPML_CCA *target, BYTE **buffer, uint32_t *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_CC) {
 	    rc = TPM_RC_SIZE;
+        target->count = 0;
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1645,6 +1648,7 @@ TSS_TPML_ALG_Unmarshalu(TPML_ALG *target, BYTE **buffer, uint32_t *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_ALG_LIST_SIZE) {
 	    rc = TPM_RC_SIZE;
+        target->count = 0;
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1667,6 +1671,7 @@ TSS_TPML_HANDLE_Unmarshalu(TPML_HANDLE *target, BYTE **buffer, uint32_t *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_HANDLES) {
 	    rc = TPM_RC_SIZE;
+        target->count = 0;
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1693,11 +1698,13 @@ TSS_TPML_DIGEST_Unmarshalu(TPML_DIGEST *target, BYTE **buffer, uint32_t *size, u
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count < minCount) {
 	    rc = TPM_RC_SIZE;
+        target->count = 0;
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > 8) {
 	    rc = TPM_RC_SIZE;
+        target->count = 0;
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1720,6 +1727,7 @@ TSS_TPML_DIGEST_VALUES_Unmarshalu(TPML_DIGEST_VALUES *target, BYTE **buffer, uin
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > HASH_COUNT) {
 	    rc = TPM_RC_SIZE;
+        target->count = 0;
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1742,6 +1750,7 @@ TSS_TPML_PCR_SELECTION_Unmarshalu(TPML_PCR_SELECTION *target, BYTE **buffer, uin
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > HASH_COUNT) {
 	    rc = TPM_RC_SIZE;
+        target->count = 0;
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1764,6 +1773,7 @@ TSS_TPML_ALG_PROPERTY_Unmarshalu(TPML_ALG_PROPERTY *target, BYTE **buffer, uint3
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_ALGS) {
 	    rc = TPM_RC_SIZE;
+        target->count = 0;
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1786,6 +1796,7 @@ TSS_TPML_TAGGED_TPM_PROPERTY_Unmarshalu(TPML_TAGGED_TPM_PROPERTY  *target, BYTE 
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_TPM_PROPERTIES) {
 	    rc = TPM_RC_SIZE;
+        target->count = 0;
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1808,6 +1819,7 @@ TSS_TPML_TAGGED_PCR_PROPERTY_Unmarshalu(TPML_TAGGED_PCR_PROPERTY *target, BYTE *
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_PCR_PROPERTIES) {
 	    rc = TPM_RC_SIZE;
+        target->count = 0;
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1830,6 +1842,7 @@ TSS_TPML_ECC_CURVE_Unmarshalu(TPML_ECC_CURVE *target, BYTE **buffer, uint32_t *s
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_ECC_CURVES) {
 	    rc = TPM_RC_SIZE;
+        target->count = 0;
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1852,6 +1865,7 @@ TSS_TPML_TAGGED_POLICY_Unmarshalu(TPML_TAGGED_POLICY *target, BYTE **buffer, uin
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_TAGGED_POLICIES) {
 	    rc = TPM_RC_SIZE;
+        target->count = 0;
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2439,6 +2453,7 @@ TSS_TPM2B_SENSITIVE_CREATE_Unmarshalu(TPM2B_SENSITIVE_CREATE *target, BYTE **buf
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size == 0) {
 	    rc = TPM_RC_SIZE;
+        target->size = 0;
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -2450,6 +2465,7 @@ TSS_TPM2B_SENSITIVE_CREATE_Unmarshalu(TPM2B_SENSITIVE_CREATE *target, BYTE **buf
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+        target->size = 0;
 	}
     }
     return rc;
@@ -3134,6 +3150,7 @@ TSS_TPM2B_ECC_POINT_Unmarshalu(TPM2B_ECC_POINT *target, BYTE **buffer, uint32_t 
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size == 0) {
 	    rc = TPM_RC_SIZE;
+        target->size = 0;
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -3145,6 +3162,7 @@ TSS_TPM2B_ECC_POINT_Unmarshalu(TPM2B_ECC_POINT *target, BYTE **buffer, uint32_t 
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+        target->size = 0;
 	}
     }
     return rc;
@@ -3641,6 +3659,7 @@ TSS_TPM2B_PUBLIC_Unmarshalu(TPM2B_PUBLIC *target, BYTE **buffer, uint32_t *size,
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size == 0) {
 	    rc = TPM_RC_SIZE;
+        target->size = 0;
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -3652,6 +3671,7 @@ TSS_TPM2B_PUBLIC_Unmarshalu(TPM2B_PUBLIC *target, BYTE **buffer, uint32_t *size,
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+        target->size = 0;
 	}
     }
     return rc;
@@ -3748,6 +3768,7 @@ TSS_TPM2B_SENSITIVE_Unmarshalu(TPM2B_SENSITIVE *target, BYTE **buffer, uint32_t 
 	if (rc == TPM_RC_SUCCESS) {
 	    if (target->t.size != startSize - *size) {
 		rc = TPM_RC_SIZE;
+        target->t.size = 0;
 	    }
 	}
     }
@@ -3839,6 +3860,7 @@ TSS_TPM2B_NV_PUBLIC_Unmarshalu(TPM2B_NV_PUBLIC *target, BYTE **buffer, uint32_t 
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size == 0) {
 	    rc = TPM_RC_SIZE;
+        target->size = 0;
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -3850,6 +3872,7 @@ TSS_TPM2B_NV_PUBLIC_Unmarshalu(TPM2B_NV_PUBLIC *target, BYTE **buffer, uint32_t 
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+        target->size = 0;
 	}
     }
     return rc;
@@ -3979,6 +4002,7 @@ TSS_TPM2B_CREATION_DATA_Unmarshalu(TPM2B_CREATION_DATA *target, BYTE **buffer, u
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+        target->size = 0;
 	}
     }
     return rc;

--- a/qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/Unmarshal12.c
+++ b/qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/Unmarshal12.c
@@ -121,6 +121,7 @@ TSS_TPM_PCR_SELECTION_Unmarshalu(TPM_PCR_SELECTION *target, BYTE **buffer, uint3
     if (rc == 0) {
 	if (target->sizeOfSelect > sizeof(target->pcrSelect)) {
 	    rc = TPM_RC_SIZE;
+	    target->sizeOfSelect = 0;
 	}
     }    
     if (rc == 0) {
@@ -219,6 +220,7 @@ TSS_TPM_SYMMETRIC_KEY_Unmarshalu(TPM_SYMMETRIC_KEY *target, BYTE **buffer, uint3
     if (rc == 0) {
 	if (target->size > sizeof(target->data)) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0;
 	}
     }    
     if (rc == 0) {
@@ -245,6 +247,7 @@ TSS_TPM_RSA_KEY_PARMS_Unmarshalu(TPM_RSA_KEY_PARMS *target, BYTE **buffer, uint3
     if (rc == 0) {
 	if (target->exponentSize > sizeof(target->exponent)) {
 	    rc = TPM_RC_SIZE;
+	    target->exponentSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -360,6 +363,7 @@ TSS_TPM_STORE_PUBKEY_Unmarshalu(TPM_STORE_PUBKEY *target, BYTE **buffer, uint32_
     if (rc == 0) {
 	if (target->keyLength > sizeof(target->key)) {
 	    rc = TPM_RC_SIZE;
+	    target->keyLength = 0;
 	}
     }    
     if (rc == 0) {
@@ -457,6 +461,7 @@ TSS_TPM_CAP_VERSION_INFO_Unmarshalu(TPM_CAP_VERSION_INFO *target, BYTE **buffer,
     if (rc == 0) {
 	if (target->vendorSpecificSize > sizeof(target->vendorSpecific)) {
 	    rc = TPM_RC_SIZE;
+	    target->vendorSpecificSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -493,6 +498,7 @@ TSS_TPM_DA_INFO_Unmarshalu(TPM_DA_INFO *target, BYTE **buffer, uint32_t *size)
     if (rc == 0) {
 	if (target->vendorDataSize > sizeof(target->vendorData)) {
 	    rc = TPM_RC_SIZE;
+        target->vendorDataSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -520,6 +526,7 @@ TSS_TPM_DA_INFO_LIMITED_Unmarshalu(TPM_DA_INFO_LIMITED *target, BYTE **buffer, u
     if (rc == 0) {
 	if (target->vendorDataSize > sizeof(target->vendorData)) {
 	    rc = TPM_RC_SIZE;
+        target->vendorDataSize = 0;
 	}
     }    
     if (rc == 0) {

--- a/qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/eventlib.c
+++ b/qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/eventlib.c
@@ -224,6 +224,7 @@ TPM_RC TSS_EVENT_Line_Unmarshal(TCG_PCR_EVENT *target, BYTE **buffer, uint32_t *
     if (rc == 0) {
 	if (target->eventDataSize > sizeof(target->event)) {
 	    rc = TPM_RC_SIZE;
+	    target->eventDataSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -254,6 +255,7 @@ TPM_RC TSS_EVENT_Line_LE_Unmarshal(TCG_PCR_EVENT *target, BYTE **buffer, uint32_
     if (rc == 0) {
 	if (target->eventDataSize > sizeof(target->event)) {
 	    rc = TPM_RC_SIZE;
+	    target->eventDataSize = 0;
 	}
     }
     if (rc == 0) {
@@ -661,6 +663,7 @@ TPM_RC TSS_EVENT2_Line_Unmarshal(TCG_PCR_EVENT2 *target, BYTE **buffer, uint32_t
     if (rc == 0) {
 	if (target->eventSize > sizeof(target->event)) {
 	    rc = TPM_RC_SIZE;
+	    target->eventSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -692,6 +695,7 @@ TPM_RC TSS_EVENT2_Line_LE_Unmarshal(TCG_PCR_EVENT2 *target, BYTE **buffer, uint3
     if (rc == 0) {
 	if (target->eventSize > sizeof(target->event)) {
 	    rc = TPM_RC_SIZE;
+	    target->eventSize = 0;
 	}
     }
     if (rc == 0) {
@@ -938,6 +942,7 @@ TSS_TPML_DIGEST_VALUES_LE_Unmarshalu(TPML_DIGEST_VALUES *target, BYTE **buffer, 
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > HASH_COUNT) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0;
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {

--- a/qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/tssmarshal12.c
+++ b/qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/tssmarshal12.c
@@ -480,6 +480,7 @@ TSS_GetCapability12_Out_Unmarshalu(GetCapability12_Out *target, TPM_ST tag, BYTE
     if (rc == 0) {
 	if (target->respSize > sizeof(target->resp)) {
 	    rc = TPM_RC_SIZE;
+	    target->respSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -513,6 +514,7 @@ TSS_MakeIdentity_Out_Unmarshalu(MakeIdentity_Out *target, TPM_ST tag, BYTE **buf
     if (rc == 0) {
 	if (target->identityBindingSize > sizeof(target->identityBinding)) {
 	    rc = TPM_RC_SIZE;
+	    target->identityBindingSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -532,6 +534,7 @@ TSS_NV_ReadValueAuth_Out_Unmarshalu(NV_ReadValueAuth_Out *target, TPM_ST tag, BY
     if (rc == 0) {
 	if (target->dataSize > sizeof(target->data)) {
 	    rc = TPM_RC_SIZE;
+        target->dataSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -551,6 +554,7 @@ TSS_NV_ReadValue_Out_Unmarshalu(NV_ReadValue_Out *target, TPM_ST tag, BYTE **buf
     if (rc == 0) {
 	if (target->dataSize > sizeof(target->data)) {
 	    rc = TPM_RC_SIZE;
+	    target->dataSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -632,6 +636,7 @@ TSS_Quote2_Out_Unmarshalu(Quote2_Out *target, TPM_ST tag, BYTE **buffer, uint32_
     if (rc == 0) {
 	if (target->sigSize > sizeof(target->sig)) {
 	    rc = TPM_RC_SIZE;
+	    target->sigSize = 0;
 	}
     }    
     if (rc == 0) {
@@ -651,6 +656,7 @@ TSS_Sign12_Out_Unmarshalu(Sign12_Out *target, TPM_ST tag, BYTE **buffer, uint32_
     if (rc == 0) {
 	if (target->sigSize > sizeof(target->sig)) {
 	    rc = TPM_RC_SIZE;
+	    target->sigSize = 0;
 	}
     }    
     if (rc == 0) {


### PR DESCRIPTION
This PR fixes a potential security vulnerability in qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils that was cloned from [{repo}](https://github.com/stefanberger/libtpms) but did not receive the security patch.

###Details:
Affected Files: 
qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/Commands12.c
qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/Unmarshal.c
qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/Unmarshal12.c
qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/eventlib.c
qemu-8.0.0/roms/skiboot/libstb/tss2/ibmtpm20tss/utils/tssmarshal12.c

Original Fix: [{original commit}](https://github.com/stefanberger/libtpms/commit/2f30d62)

###What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

###References:
[{original commit}](https://github.com/stefanberger/libtpms/commit/2f30d62)
[{link to original CVE/bug id}](https://nvd.nist.gov/vuln/detail/CVE-2021-3623)

Please review and merge this PR to ensure your repository is protected against this potential vulnerability
