### PR TITLE
Fix potential vulnerable cloned functions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: output
 
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: output
 
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,19 +16,19 @@ jobs:
         run: |
           brew install create-dmg
 
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: output
 
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: qemu_macos
 
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,19 +16,19 @@ jobs:
         run: |
           brew install create-dmg
 
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: output
 
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: qemu_macos
 
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,19 +12,19 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: output
 
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: qemu_w64
 
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@v8
         with:
           workflow: main_ci.yml
           workflow_conclusion: success

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,19 +12,19 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: output
 
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success
           name: qemu_w64
 
-      - uses: dawidd6/action-download-artifact@v8
+      - uses: dawidd6/action-download-artifact@v9
         with:
           workflow: main_ci.yml
           workflow_conclusion: success

--- a/linux-6.1.11/include/net/netfilter/nf_tables.h
+++ b/linux-6.1.11/include/net/netfilter/nf_tables.h
@@ -177,9 +177,9 @@ static inline __be32 nft_reg_load_be32(const u32 *sreg)
 	return *(__force __be32 *)sreg;
 }
 
-static inline void nft_reg_store64(u32 *dreg, u64 val)
+static inline void nft_reg_store64(u64 *dreg, u64 val)
 {
-	put_unaligned(val, (u64 *)dreg);
+	put_unaligned(val, dreg);
 }
 
 static inline u64 nft_reg_load64(const u32 *sreg)

--- a/linux-6.1.11/net/netfilter/nft_byteorder.c
+++ b/linux-6.1.11/net/netfilter/nft_byteorder.c
@@ -38,13 +38,14 @@ void nft_byteorder_eval(const struct nft_expr *expr,
 
 	switch (priv->size) {
 	case 8: {
+		u64 *dst64 = (void *)dst;
 		u64 src64;
 
 		switch (priv->op) {
 		case NFT_BYTEORDER_NTOH:
 			for (i = 0; i < priv->len / 8; i++) {
 				src64 = nft_reg_load64(&src[i]);
-				nft_reg_store64(&dst[i],
+				nft_reg_store64(&dst64[i],
 						be64_to_cpu((__force __be64)src64));
 			}
 			break;
@@ -52,7 +53,7 @@ void nft_byteorder_eval(const struct nft_expr *expr,
 			for (i = 0; i < priv->len / 8; i++) {
 				src64 = (__force __u64)
 					cpu_to_be64(nft_reg_load64(&src[i]));
-				nft_reg_store64(&dst[i], src64);
+				nft_reg_store64(&dst64[i], src64);
 			}
 			break;
 		}

--- a/linux-6.1.11/net/netfilter/nft_meta.c
+++ b/linux-6.1.11/net/netfilter/nft_meta.c
@@ -63,7 +63,7 @@ nft_meta_get_eval_time(enum nft_meta_keys key,
 {
 	switch (key) {
 	case NFT_META_TIME_NS:
-		nft_reg_store64(dest, ktime_get_real_ns());
+		nft_reg_store64((u64 *)dest, ktime_get_real_ns());
 		break;
 	case NFT_META_TIME_DAY:
 		nft_reg_store8(dest, nft_meta_weekday());


### PR DESCRIPTION
Hi again,

I identified another potential vulnerability in cloned functions in `linux-6.1.11/net/netfilter/nft_byteorder.c`sourced from [torvalds/linux](https://github.com/torvalds/linux). This issue, originally reported in [CVE-2024-0607](https://nvd.nist.gov/vuln/detail/cve-2024-0607), was resolved in the repository via this commit https://github.com/torvalds/linux/commit/c301f0981fdd3fd1ffac6836b423c4d7a8e0eb63.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!