### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/linux-6.1.11/drivers/gpu/drm/drm_atomic.c
+++ b/linux-6.1.11/drivers/gpu/drm/drm_atomic.c
@@ -140,6 +140,12 @@ drm_atomic_state_init(struct drm_device *dev, struct drm_atomic_state *state)
 	if (!state->planes)
 		goto fail;
 
+	/*
+	 * Because drm_atomic_state can be committed asynchronously we need our
+	 * own reference and cannot rely on the on implied by drm_file in the
+	 * ioctl call.
+	 */
+	drm_dev_get(dev);
 	state->dev = dev;
 
 	drm_dbg_atomic(dev, "Allocated atomic state %p\n", state);
@@ -299,7 +305,8 @@ EXPORT_SYMBOL(drm_atomic_state_clear);
 void __drm_atomic_state_free(struct kref *ref)
 {
 	struct drm_atomic_state *state = container_of(ref, typeof(*state), ref);
-	struct drm_mode_config *config = &state->dev->mode_config;
+	struct drm_device *dev = state->dev;
+	struct drm_mode_config *config = &dev->mode_config;
 
 	drm_atomic_state_clear(state);
 
@@ -311,6 +318,8 @@ void __drm_atomic_state_free(struct kref *ref)
 		drm_atomic_state_default_release(state);
 		kfree(state);
 	}
+
+	drm_dev_put(dev);
 }
 EXPORT_SYMBOL(__drm_atomic_state_free);
 


### PR DESCRIPTION
This PR fixes a potential security vulnerability in linux-6.1.11/drivers/gpu/drm/drm_atomic.c

###Details:
Affected File: linux-6.1.11/drivers/gpu/drm/drm_atomic.c
Original Fix: https://github.com/torvalds/linux/commit/4e076c73e4f6e90816b30fcd4a0d7ab365087255


###What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

###References:
- https://nvd.nist.gov/vuln/detail/CVE-2023-51043